### PR TITLE
Fixed a typo in the CloverLeaf Tutorial examples

### DIFF
--- a/Tutorials/CloverLeaf/cloverleaf_bm16_short.py
+++ b/Tutorials/CloverLeaf/cloverleaf_bm16_short.py
@@ -72,8 +72,8 @@ class CloverLeafTest(hack.HackathonBase):
        }
 
        # CloverLeaf prints the 'Wall clock' every timestep - so extract all lines matching the regex
-       pref_regex = r'\s+Wall clock\s+(\S+)'
+       perf_regex = r'\s+Wall clock\s+(\S+)'
        self.perf_patterns = {
-               'Total Time': sn.extractsingle(pref_regex, self.logfile, 1, float, item=-1)
+               'Total Time': sn.extractsingle(perf_regex, self.logfile, 1, float, item=-1)
        }
 

--- a/Tutorials/CloverLeaf/cloverleaf_bm16_short_exclusive.py
+++ b/Tutorials/CloverLeaf/cloverleaf_bm16_short_exclusive.py
@@ -76,8 +76,8 @@ class CloverLeafTest(hack.HackathonBase):
        }
 
        # CloverLeaf prints the 'Wall clock' every timestep - so extract all lines matching the regex
-       pref_regex = r'\s+Wall clock\s+(\S+)'
+       perf_regex = r'\s+Wall clock\s+(\S+)'
        self.perf_patterns = {
-               'Total Time': sn.extractsingle(pref_regex, self.logfile, 1, float, item=-1)
+               'Total Time': sn.extractsingle(perf_regex, self.logfile, 1, float, item=-1)
        }
 

--- a/Tutorials/CloverLeaf/cloverleaf_bm512_short.py
+++ b/Tutorials/CloverLeaf/cloverleaf_bm512_short.py
@@ -70,7 +70,7 @@ class CloverLeafTest(hack.HackathonBase):
 
        # CloverLeaf prints the 'Wall clock' every timestep - so extract all lines matching the regex
               # CloverLeaf prints the 'Wall clock' every timestep - so extract the last one
-       pref_regex = r'\s+Wall clock\s+(\S+)'
+       perf_regex = r'\s+Wall clock\s+(\S+)'
        self.perf_patterns = {
-               'Total Time': sn.extractsingle(pref_regex, self.logfile, 1, float, item=-1)
+               'Total Time': sn.extractsingle(perf_regex, self.logfile, 1, float, item=-1)
        }


### PR DESCRIPTION
There appears to be a typo in a variable name for the CloverLeaf examples. It doesn't prevent the code from working. It is just slightly confusing. This PR does `s/pref_regex/perf_regex` on the three different ReFrame examples. 

I think the intention was to name this variable `perf` as in short for performance. The spelling now matches `perf_patterns` on the line below.